### PR TITLE
add more modul for engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,41 @@ Tipe pengembang ini akan berhubungan dengan desain antarmuka, baik web, mobile m
 - [OpenCV](http://opencv.org) - a library of programming functions mainly aimed at real-time computer vision.
 - [Git](https://git-scm.com/) - for Versioning Control
 
+#### 7. Electronics Engineer (EE)
+- [Eagle](http://www.cadsoft.de/) - A printed circuit board design tool.
+- [gEDA](http://www.geda-project.org/) - GPL suite of Electronic Design Automation tools.
+- [Icarus Verilog](http://icarus.com/eda/verilog/) - Icarus Verilog is a Verilog simulation and synthesis tool. It operates as a compiler, compiling source code written in Verilog (IEEE-1364) into some target format.
+- [KiCad](http://kicad-pcb.org/) - is a portable, cross-platform, Free/Libre/Open-Source EDA Suite that is capable of schematic and printed circuit board design.
+- [oregano](https://github.com/drahnr/oregano) - Schematic capture, netlists, and spice for simulations.
+- [Qucs](http://qucs.sourceforge.net/index.html) - An integrated circuit simulator.
+- [Fritzing](http://fritzing.org/) - electronic design automation software.
+
+### 8. CAD Engineer (CadE)
+- [BRL-CAD](http://www.brlcad.org/) - A Open Source 3D-CAD program. It is a Constructive Solid Geometry (CSG) solid modeling system with over 20 years development and production use by the U.S. military.
+- [FreeCAD](http://www.freecadweb.org/) - Modern Open Source parametric CAD modeler geared toward mechanical engineering, product design and architecture among others, fully expandable through Python.
+- [gCAD3D](http://www.gcad3d.org/) - A 3D-surface-CAD/CAM. Program is freeware.
+- [LibreCAD](http://librecad.org/cms/home.html) - A 2D CAD application. Highly active fork of QCad, ported to Qt4.
+- [MEDUSA](http://www.cad-schroer.com/products/medusa4-personal.html) - 2D/3D commercial mechanical engineering CAD. Free for personal use only.
+- [Varkon](http://varkon.sourceforge.net/) - Open Source 3D- (parametric) and 2D-Development platform for a CAD program.
+
+### 9. Mathematical Analysis Engineer (MaTE)
+- [Octave](http://www.gnu.org/software/octave/) - GNU Octave is a FOSS high-level interpreted language, primarily intended for numerical computations of linear and nonlinear problems.
+- [Sage](http://www.sagemath.org/) - A free open-source mathematics software system licensed under the GPL.
+- [Scilab](http://www.scilab.org/) - An open source, cross-platform numerical computational package and a high-level, numerically oriented programming language. It can be used for signal processing, statistical analysis, image enhancement, fluid dynamics simulations, numerical optimization, and modeling, simulation of explicit and implicit dynamical systems and (if the corresponding toolbox is installed) symbolic manipulations.
+
+### 10. Finite Element Analysis Engineer (FEAE)
+- [Elmer](http://www.csc.fi/english/pages/elmer) - Elmer is an open source computational tool for multi-physics problems. It has been developed by CSC in collaboration with Finnish universities, research laboratories and industry.
+- [Gmsh](http://www.geuz.org/gmsh/) - An automatic 3D finite element grid generator with a built-in CAD engine and FEM post-processor.
+- [Netgen](https://ngsolve.org/) - Netgen is a multi-platform automatic mesh generation tool written in C++ capable of generating meshes in two and three dimensions. Netgen has FEM-ngolve CFD-ngflow extensions.
+- [OOFem](http://www.oofem.org/) - A free finite element code with object oriented architecture for solving mechanical, transport and fluid mechanics problems.
+- [Salome](http://www.code-aster.org/V2/spip.php?article303) - A Open Source software suite including Pre-/Post processing Tools: 3D-CAD, Mesher, FEM-Software
+
+### 11. Fluid Mechanic Engineer (FME)
+- [GHydraulics](http://epanet.de/ghydraulics/) - It's a Quantum GIS plugin that allows to export water supply networks for analysis in EPANET.
+- [OpenFOAM](http://www.openfoam.com/) - A free, open source CFD software package to solve anything from complex fluid flows involving chemical reactions, turbulence and heat transfer, to solid dynamics and electromagnetics.
+- [SU2](http://su2.stanford.edu/) - A free and open source suite of tools for analysis and shape design using gradient-based optimization.
+- [XFoil](http://ubuntuforums.org/showthread.php?t=288920) - A program to design and/or calculate airfoils.
+
 Masih terasa hambar? Tambahkan versimu di [sini](https://github.com/tealinuxos/modularitea/issues/new)
 
 # Kontribusi


### PR DESCRIPTION
Dari artikel "UbuntuEngineer" [https://help.ubuntu.com/community/UbuntuEngineering](https://help.ubuntu.com/community/UbuntuEngineering). Sudah di pilah yang freeware atau yang opensource, yang commersial tidak dimasukan. Website sudah di update dari masing-masing atom.